### PR TITLE
feat: add _signTypedData for backward compatibility

### DIFF
--- a/packages/sdk/src/ZeroDevSigner.ts
+++ b/packages/sdk/src/ZeroDevSigner.ts
@@ -14,7 +14,7 @@ import { UserOperationStruct, GnosisSafe__factory } from '@zerodevapp/contracts'
 import { UpdateController } from './update'
 import * as constants from './constants'
 import { logTransactionReceipt } from './api'
-import { hexZeroPad } from 'ethers/lib/utils'
+import { hexZeroPad, _TypedDataEncoder } from 'ethers/lib/utils'
 import { fixSignedData, getERC1155Contract, getERC20Contract, getERC721Contract } from './utils'
 import MoralisApiService from './services/MoralisApiService'
 
@@ -187,9 +187,14 @@ export class ZeroDevSigner extends Signer {
     return sig
   }
 
-  async signTypedData(typedData: any) {
+  async signTypedData(typedData: any): Promise<string> {
     const digest = TypedDataUtils.encodeDigest(typedData)
     return await this.signMessage(digest)
+  }
+
+  async _signTypedData(domain: any, types: any, value: any): Promise<string> {
+    const message = _TypedDataEncoder.getPayload(domain, types, value)
+    return await this.signTypedData(message)
   }
 
   async signTransaction(transaction: Deferrable<TransactionRequest>): Promise<string> {

--- a/packages/sdk/test/3-ZeroDevSigner.test.ts
+++ b/packages/sdk/test/3-ZeroDevSigner.test.ts
@@ -232,7 +232,7 @@ describe('ZeroDevSigner, Provider', function () {
 			verifyingContract: "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
 		};
 
-		const messageTypes = {
+		const typesWithoutEIP712Domain = {
 			Person: [
 			{ name: "name", type: "string" },
 			{ name: "wallet", type: "address" },
@@ -251,7 +251,7 @@ describe('ZeroDevSigner, Provider', function () {
 			{ name: "chainId", type: "uint256" },
 			{ name: "verifyingContract", type: "address" },
 			],
-			...messageTypes,
+			...typesWithoutEIP712Domain,
 		};
 
 		const message = {
@@ -278,7 +278,7 @@ describe('ZeroDevSigner, Provider', function () {
 		const eip712Signature = await signer.signTypedData(typedData);
 		const _eip712Signature = await signer._signTypedData(
 			domain,
-			messageTypes,
+			typesWithoutEIP712Domain,
 			message
 		);
 

--- a/packages/sdk/test/3-ZeroDevSigner.test.ts
+++ b/packages/sdk/test/3-ZeroDevSigner.test.ts
@@ -223,67 +223,67 @@ describe('ZeroDevSigner, Provider', function () {
       expect(await signer.getBalance()).lessThan(firstAccountBalance)
     })
 
-	it.only("should support ethers v5 _signTypedData() for backward compatibility", async function () {
+	it("should [temporarily] support ethers v5 _signTypedData() for backward compatibility", async function () {
 		// Use example types from EIP-712 specifications (https://eips.ethereum.org/EIPS/eip-712)
 		const domain = {
-		  name: "Ether Mail",
-		  version: "1",
-		  chainId: 1,
-		  verifyingContract: "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
+			name: "Ether Mail",
+			version: "1",
+			chainId: 1,
+			verifyingContract: "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
 		};
-  
+
 		const messageTypes = {
-		  Person: [
+			Person: [
 			{ name: "name", type: "string" },
 			{ name: "wallet", type: "address" },
-		  ],
-		  Mail: [
+			],
+			Mail: [
 			{ name: "from", type: "Person" },
 			{ name: "to", type: "Person" },
 			{ name: "contents", type: "string" },
-		  ],
+			],
 		};
 
 		const typesWithEIP712Domain = {
-		  EIP712Domain: [
+			EIP712Domain: [
 			{ name: "name", type: "string" },
 			{ name: "version", type: "string" },
 			{ name: "chainId", type: "uint256" },
 			{ name: "verifyingContract", type: "address" },
-		  ],
-		  ...messageTypes,
+			],
+			...messageTypes,
 		};
 
 		const message = {
-		  from: {
+			from: {
 			name: "Cow",
 			wallet: "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826",
-		  },
-		  to: {
+			},
+			to: {
 			name: "Bob",
 			wallet: "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
-		  },
-		  contents: "Hello, Bob!",
+			},
+			contents: "Hello, Bob!",
 		};
 		const primaryType = "Mail";
-  
+
 		const typedData = {
-		  types: typesWithEIP712Domain,
-		  domain,
-		  primaryType,
-		  message,
+			types: typesWithEIP712Domain,
+			domain,
+			primaryType,
+			message,
 		};
-  
+
 		const signer = aaProvider.getSigner();
 		const eip712Signature = await signer.signTypedData(typedData);
 		const _eip712Signature = await signer._signTypedData(
-		  domain,
-		  messageTypes,
-		  message
+			domain,
+			messageTypes,
+			message
 		);
-  
+
 		expect(eip712Signature).to.be.equal(_eip712Signature);
-	  });
+		});
 
   
     context('#modules', () => {

--- a/packages/sdk/test/3-ZeroDevSigner.test.ts
+++ b/packages/sdk/test/3-ZeroDevSigner.test.ts
@@ -223,7 +223,7 @@ describe('ZeroDevSigner, Provider', function () {
       expect(await signer.getBalance()).lessThan(firstAccountBalance)
     })
 
-	it("should [temporarily] support ethers v5 _signTypedData() for backward compatibility", async function () {
+	it("should support ethers v5 _signTypedData() for backward compatibility", async function () {
 		// Use example types from EIP-712 specifications (https://eips.ethereum.org/EIPS/eip-712)
 		const domain = {
 			name: "Ether Mail",

--- a/packages/sdk/test/3-ZeroDevSigner.test.ts
+++ b/packages/sdk/test/3-ZeroDevSigner.test.ts
@@ -223,6 +223,68 @@ describe('ZeroDevSigner, Provider', function () {
       expect(await signer.getBalance()).lessThan(firstAccountBalance)
     })
 
+	it.only("should support ethers v5 _signTypedData() for backward compatibility", async function () {
+		// Use example types from EIP-712 specifications (https://eips.ethereum.org/EIPS/eip-712)
+		const domain = {
+		  name: "Ether Mail",
+		  version: "1",
+		  chainId: 1,
+		  verifyingContract: "0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC",
+		};
+  
+		const messageTypes = {
+		  Person: [
+			{ name: "name", type: "string" },
+			{ name: "wallet", type: "address" },
+		  ],
+		  Mail: [
+			{ name: "from", type: "Person" },
+			{ name: "to", type: "Person" },
+			{ name: "contents", type: "string" },
+		  ],
+		};
+
+		const typesWithEIP712Domain = {
+		  EIP712Domain: [
+			{ name: "name", type: "string" },
+			{ name: "version", type: "string" },
+			{ name: "chainId", type: "uint256" },
+			{ name: "verifyingContract", type: "address" },
+		  ],
+		  ...messageTypes,
+		};
+
+		const message = {
+		  from: {
+			name: "Cow",
+			wallet: "0xCD2a3d9F938E13CD947Ec05AbC7FE734Df8DD826",
+		  },
+		  to: {
+			name: "Bob",
+			wallet: "0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB",
+		  },
+		  contents: "Hello, Bob!",
+		};
+		const primaryType = "Mail";
+  
+		const typedData = {
+		  types: typesWithEIP712Domain,
+		  domain,
+		  primaryType,
+		  message,
+		};
+  
+		const signer = aaProvider.getSigner();
+		const eip712Signature = await signer.signTypedData(typedData);
+		const _eip712Signature = await signer._signTypedData(
+		  domain,
+		  messageTypes,
+		  message
+		);
+  
+		expect(eip712Signature).to.be.equal(_eip712Signature);
+	  });
+
   
     context('#modules', () => {
   


### PR DESCRIPTION
This adds `_signTypedData()` to ZeroDevSigner, to be backward compatible with dApps that are still using ethers v5's _signTypedData (for example using [SeaportJS](https://github.com/ProjectOpenSea/seaport-js/blob/f1a0a3d9da6517719bf1f60c01dcd16ed02b6588/src/seaport.ts#L514)). 

Migrating an existing project from ethers v5 to v6 can be quite tedious (from my experience) and so I assume a lot of people will stick to v5. Roughly 2.3k files on GitHub currently use `_signTypedData`

<img width="1102" alt="image" src="https://user-images.githubusercontent.com/100505855/227757823-d30550de-5b0d-4360-bedf-119e1bc54b82.png">

For reference, link to ethers v5 JsonRpcSigner's `_signTypedData`: https://github.com/ethers-io/ethers.js/blob/v5.7/packages/providers/src.ts/json-rpc-provider.ts#L336