### PR TITLE
feat: uses jiffyscan for transaction confirmation

### DIFF
--- a/packages/sdk/src/UserOperationEventListener.ts
+++ b/packages/sdk/src/UserOperationEventListener.ts
@@ -38,14 +38,10 @@ export class UserOperationEventListener {
     const filter = this.entryPoint.filters.UserOperationEvent(this.userOpHash)
     // listener takes time... first query directly:
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    setTimeout(async () => {
-      const res = await this.entryPoint.queryFilter(filter, 'latest')
-      if (res.length > 0) {
-        void this.listenerCallback(res[0])
-      } else {
-        this.entryPoint.once(filter, this.boundLisener)
-      }
-    }, 100)
+    this.entryPoint.once(filter, this.boundLisener)
+    void this.entryPoint.queryFilter(filter, 'latest').then(res => {
+      if (res.length > 0) void this.listenerCallback(res[0])
+    })
   }
 
   stop(): void {

--- a/packages/sdk/src/ZeroDevProvider.ts
+++ b/packages/sdk/src/ZeroDevProvider.ts
@@ -93,7 +93,7 @@ export class ZeroDevProvider extends BaseProvider {
   async constructUserOpTransactionResponse(userOp1: UserOperationStruct): Promise<TransactionResponse> {
     const userOp = await resolveProperties(userOp1)
     const userOpHash = await this.entryPoint.getUserOpHash(userOp)
-    const waitPromise = getUserOpReceipt(this.entryPoint, userOp.sender, userOpHash, this.chainId)
+    const waitPromise = getUserOpReceipt(this.entryPoint, userOp.sender, userOpHash, this.chainId, userOp.nonce)
 
     // session key nonces use 2D nonces, so it's going to overflow Ethers
     // https://github.com/ethers-io/ethers.js/blob/0802b70a724321f56d4c170e4c8a46b7804dfb48/src.ts/transaction/transaction.ts#L44

--- a/packages/sdk/src/constants.ts
+++ b/packages/sdk/src/constants.ts
@@ -105,3 +105,18 @@ export const ERC20_APPROVAL_AMOUNT: { [key: string]: BigNumberish } = {
 
   '0x3870419Ba2BBf0127060bCB37f69A1b1C090992B': ethers.utils.parseUnits('10', 18)
 }
+
+export const JIFFYSCAN_CHAIN_ID_TO_NAME: {[key: number]: string} = {
+  1: 'mainnet',
+  5: 'goerli',
+  137: 'matic',
+  80001: 'mumbai',
+  10: 'optimism',
+  420: 'optimism-goerli',
+  42161: 'arbitrum-one',
+  421613: 'arbitrum-goerli',
+  43114: 'avalanche',
+  43113: 'avalanche-fuji',
+  56: 'bsc',
+  84531: 'base-testnet'
+}

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -1,5 +1,5 @@
 import { Provider, TransactionReceipt } from '@ethersproject/abstract-provider'
-import { BigNumber, Contract, ethers } from 'ethers'
+import { BigNumber, BigNumberish, Contract, ethers } from 'ethers'
 import { hexValue } from 'ethers/lib/utils'
 
 import * as constants from './constants'
@@ -60,12 +60,12 @@ export const getERC1155Contract = (provider: Provider, address: string): Contrac
   return new Contract(address, constants.ERC1155_ABI, provider)
 }
 
-export async function getUserOpReceipt (entryPoint: EntryPoint, sender: string, userOpHash: string, chainId: number): Promise<TransactionReceipt> {
+export async function getUserOpReceipt (entryPoint: EntryPoint, sender: string, userOpHash: string, chainId: number, nonce?: BigNumberish): Promise<TransactionReceipt> {
   return await new Promise<TransactionReceipt>((resolve, reject) => {
     const fallback: (reason?: string) => void = (reason) => {
       // if (reason !== undefined) console.log(reason)
       new UserOperationEventListener(
-        resolve, reject, entryPoint, sender, userOpHash
+        resolve, reject, entryPoint, sender, userOpHash, nonce
       ).start()
     }
 

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -77,6 +77,7 @@ export async function getUserOpReceipt (entryPoint: EntryPoint, sender: string, 
               if (constants.JIFFYSCAN_CHAIN_ID_TO_NAME[chainId] === userOpReceipt.network) {
                 resolve({
                   ...userOpReceipt,
+                  logs: [],
                   transactionHash: userOpHash,
                   bundleTransactionHash: userOpReceipt.transactionHash
                 })


### PR DESCRIPTION
Using Jiffyscan as the primary option and the old method as a fallback.